### PR TITLE
Sveltos configuration

### DIFF
--- a/argocd-sveltos-clusterapi-eks/clusterprofile-cert-manager.yaml
+++ b/argocd-sveltos-clusterapi-eks/clusterprofile-cert-manager.yaml
@@ -1,0 +1,22 @@
+# This Sveltos configuration deploys cert-manager helm chart in
+# any production or staging cluster
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: deploy-cert-manager
+spec:
+  clusterSelector:
+    matchExpressions:
+    - {key: env, operator: In, values: [staging, production]}
+  syncMode: Continuous
+  helmCharts:
+  - repositoryURL:    https://charts.jetstack.io
+    repositoryName:   jetstack
+    chartName:        jetstack/cert-manager
+    chartVersion:     v1.16.3
+    releaseName:      cert-manager
+    releaseNamespace: cert-manager
+    helmChartAction:  Install
+    values: |
+      crds:
+        enabled: true

--- a/argocd-sveltos-clusterapi-eks/clusterprofile-create-eks.yaml
+++ b/argocd-sveltos-clusterapi-eks/clusterprofile-create-eks.yaml
@@ -1,0 +1,21 @@
+# This configuration instructs Sveltos to create, via CLusterAPI, a new EKS
+# cluster for every new user
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: deploy-resources
+spec:
+  clusterSelector:
+    matchLabels:
+      type: mgmt
+  templateResourceRefs:
+  - resource: # This refers to the ConfigMap in the management cluster containing all users
+      apiVersion: v1
+      kind: ConfigMap
+      name: existing-users
+      namespace: default
+    identifier: Users
+  policyRefs:
+  - name: deploy-eks-cluster
+    namespace: default
+    kind: ConfigMap

--- a/argocd-sveltos-clusterapi-eks/clusterprofile-kyverno.yaml
+++ b/argocd-sveltos-clusterapi-eks/clusterprofile-kyverno.yaml
@@ -1,0 +1,123 @@
+# This Sveltos configuration deploys kyverno helm chart with replicas 3 in all production cluster
+# This Sveltos configuration deploys kyverno helm chart with replicas 1 in all staging cluster
+# This Sveltos configuration deploys kyverno admission policy disallow-latest-tag in any production or staging cluster
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: deploy-kyverno-staging
+spec:
+  dependsOn:
+  - deploy-cert-manager
+  clusterSelector:
+    matchLabels:
+      env: staging 
+  syncMode: Continuous
+  helmCharts:
+  - repositoryURL:    https://kyverno.github.io/kyverno/
+    repositoryName:   kyverno
+    chartName:        kyverno/kyverno
+    chartVersion:     3.3.4
+    releaseName:      kyverno-latest
+    releaseNamespace: kyverno
+    helmChartAction:  Install
+    values: |
+      admissionController:
+        replicas: 1
+      backgroundController:
+        replicas: 1
+      cleanupController:
+        replicas: 1
+      reportsController:
+        replicas: 1
+---
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: deploy-kyverno-production
+spec:
+  dependsOn:
+  - deploy-cert-manager
+  clusterSelector:
+    matchLabels:
+      env: production 
+  syncMode: Continuous
+  helmCharts:
+  - repositoryURL:    https://kyverno.github.io/kyverno/
+    repositoryName:   kyverno
+    chartName:        kyverno/kyverno
+    chartVersion:     3.3.4
+    releaseName:      kyverno-latest
+    releaseNamespace: kyverno
+    helmChartAction:  Install
+    values: |
+      admissionController:
+        replicas: 3
+      backgroundController:
+        replicas: 3
+      cleanupController:
+        replicas: 3
+      reportsController:
+        replicas: 3
+---
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: deploy-kyverno-resources
+spec:
+  dependsOn:
+  - deploy-kyverno
+  clusterSelector:
+    matchExpressions:
+    - {key: env, operator: In, values: [staging, production]}
+  policyRefs:
+  - name: disallow-latest-tag # contains Kyverno ClusterPolicy
+    namespace: default
+    kind: ConfigMap
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: disallow-latest-tag
+  namespace: default
+data:
+  kyverno.yaml: |
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      name: disallow-latest-tag
+      annotations:
+        policies.kyverno.io/title: Disallow Latest Tag
+        policies.kyverno.io/category: Best Practices
+        policies.kyverno.io/severity: medium
+        policies.kyverno.io/subject: Pod
+        policies.kyverno.io/description: >-
+          The ':latest' tag is mutable and can lead to unexpected errors if the
+          image changes. A best practice is to use an immutable tag that maps to
+          a specific version of an application Pod. This policy validates that the image
+          specifies a tag and that it is not called `latest`.      
+    spec:
+      validationFailureAction: audit
+      background: true
+      rules:
+      - name: require-image-tag
+        match:
+          resources:
+            kinds:
+            - Pod
+        validate:
+          message: "An image tag is required."
+          pattern:
+            spec:
+              containers:
+              - image: "*:*"
+      - name: validate-image-tag
+        match:
+          resources:
+            kinds:
+            - Pod
+        validate:
+          message: "Using a mutable image tag e.g. 'latest' is not allowed."
+          pattern:
+            spec:
+              containers:
+              - image: "!*:latest"

--- a/argocd-sveltos-clusterapi-eks/clusterprofile-prometheus-grafana.yaml
+++ b/argocd-sveltos-clusterapi-eks/clusterprofile-prometheus-grafana.yaml
@@ -1,0 +1,29 @@
+# This Sveltos configuration deploys prometheus and grafana helm chart in all production cluster
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: prometheus-grafana
+spec:
+  dependsOn:
+  - deploy-cert-manager
+  - deploy-kyverno
+  - deploy-kyverno-resources
+  clusterSelector:
+    matchLabels:
+      env: production
+  syncMode: Continuous
+  helmCharts:
+  - repositoryURL:    https://prometheus-community.github.io/helm-charts
+    repositoryName:   prometheus-community
+    chartName:        prometheus-community/prometheus
+    chartVersion:     26.0.0
+    releaseName:      prometheus
+    releaseNamespace: prometheus
+    helmChartAction:  Install
+  - repositoryURL:    https://grafana.github.io/helm-charts
+    repositoryName:   grafana
+    chartName:        grafana/grafana
+    chartVersion:     8.6.4
+    releaseName:      grafana
+    releaseNamespace: grafana
+    helmChartAction:  Install

--- a/argocd-sveltos-clusterapi-eks/deploy-eks-cluster.yaml
+++ b/argocd-sveltos-clusterapi-eks/deploy-eks-cluster.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+data:
+  capi-eks.yaml: "{{- if index (getResource \"Users\") \"data\" }}\n  {{- range $key,
+    $value := (getResource \"Users\").data }}\n    apiVersion: cluster.x-k8s.io/v1beta1\n
+    \   kind: Cluster\n    metadata:\n      name: capi-eks-{{ $key }}\n      namespace:
+    {{ $key }}\n      labels:\n        type: {{ $value }}\n    spec:\n      clusterNetwork:\n
+    \       pods:\n          cidrBlocks:\n          - 192.168.0.0/16\n      controlPlaneRef:\n
+    \       apiVersion: controlplane.cluster.x-k8s.io/v1beta2\n        kind: AWSManagedControlPlane\n
+    \       name: capi-eks-control-plane-{{ $key }}\n      infrastructureRef:\n        apiVersion:
+    infrastructure.cluster.x-k8s.io/v1beta2\n        kind: AWSManagedCluster\n        name:
+    capi-eks-{{ $key }}\n---\n    apiVersion: infrastructure.cluster.x-k8s.io/v1beta2\n
+    \   kind: AWSManagedCluster\n    metadata:\n      name: capi-eks-{{ $key }}\n
+    \     namespace: {{ $key }}\n    spec: {}\n---\n    apiVersion: controlplane.cluster.x-k8s.io/v1beta2\n
+    \   kind: AWSManagedControlPlane\n    metadata:\n      name: capi-eks-control-plane-{{
+    $key }}\n      namespace: {{ $key }}\n    spec:\n      region: us-east-1\n      sshKeyName:
+    capi-eks\n      version: v1.29.0\n---\n    apiVersion: cluster.x-k8s.io/v1beta1\n
+    \   kind: MachinePool\n    metadata:\n      name: capi-eks-pool-0-{{ $key }}\n
+    \     namespace: {{ $key }}\n    spec:\n      clusterName: capi-eks-{{ $key }}\n
+    \     replicas: 2\n      template:\n        spec:\n          bootstrap:\n            dataSecretName:
+    \"\"\n          clusterName: capi-eks-{{ $key }}\n          infrastructureRef:\n
+    \           apiVersion: infrastructure.cluster.x-k8s.io/v1beta2\n            kind:
+    AWSManagedMachinePool\n            name: capi-eks-pool-0-{{ $key }}\n---\n    apiVersion:
+    infrastructure.cluster.x-k8s.io/v1beta2\n    kind: AWSManagedMachinePool\n    metadata:\n
+    \     name: capi-eks-pool-0-{{ $key }}\n      namespace: {{ $key }}\n    spec:
+    {}\n---    \n  {{- end }}\n{{- end }}\n"
+kind: ConfigMap
+metadata:
+  name: deploy-eks-cluster
+  namespace: default
+  annotations:
+    projectsveltos.io/template: ok

--- a/argocd-sveltos-clusterapi-eks/existing-users.yaml
+++ b/argocd-sveltos-clusterapi-eks/existing-users.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: existing-users
+  namespace: default


### PR DESCRIPTION
1. deploy cert-manager, kyverno (replicas 3), prometheus and grafana helm charts to any production cluster
2. deploy cert-manager, kyverno (replicas 3), prometheus and grafana helm charts to any staging cluster

This configuration also instructs Sveltos to watch a ConfigMap named `existing-users` in the `default`namespace. This ConfigMap contains in its data section all existing users in the format: user-id: cluster-type
where cluster-type can be either production or staging.

Anytime a new user is added, Sveltos creates the ClusterAPI resources to create a new cluster. The label `type: cluster-type` is added to any newly created cluster